### PR TITLE
Allow forced registration of extension by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+.pytest_cache/
 *.py[cod]
 *$py.class
 

--- a/spacymoji/__init__.py
+++ b/spacymoji/__init__.py
@@ -37,7 +37,8 @@ class Emoji(object):
     name = 'emoji'
 
     def __init__(self, nlp, merge_spans=True, lookup={}, pattern_id='EMOJI',
-                 attrs=('has_emoji', 'is_emoji', 'emoji_desc', 'emoji')):
+                 attrs=('has_emoji', 'is_emoji', 'emoji_desc', 'emoji'),
+                 force_extension=True):
         """Initialise the pipeline component.
 
         nlp (Language): The shared nlp object. Used to initialise the matcher
@@ -59,12 +60,12 @@ class Emoji(object):
         emoji_patterns = list(nlp.tokenizer.pipe(EMOJI.keys()))
         self.matcher.add(pattern_id, None, *emoji_patterns)
         # Add attributes
-        Doc.set_extension(self._has_emoji, getter=self.has_emoji)
-        Doc.set_extension(self._emoji, getter=self.iter_emoji)
-        Span.set_extension(self._has_emoji, getter=self.has_emoji)
-        Span.set_extension(self._emoji, getter=self.iter_emoji)
-        Token.set_extension(self._is_emoji, default=False)
-        Token.set_extension(self._emoji_desc, getter=self.get_emoji_desc)
+        Doc.set_extension(self._has_emoji, getter=self.has_emoji, force=force_extension)
+        Doc.set_extension(self._emoji, getter=self.iter_emoji, force=force_extension)
+        Span.set_extension(self._has_emoji, getter=self.has_emoji, force=force_extension)
+        Span.set_extension(self._emoji, getter=self.iter_emoji, force=force_extension)
+        Token.set_extension(self._is_emoji, default=False, force=force_extension)
+        Token.set_extension(self._emoji_desc, getter=self.get_emoji_desc, force=force_extension)
 
     def __call__(self, doc):
         """Apply the pipeline component to a `Doc` object.


### PR DESCRIPTION
This is to avoid `ValueError: [E090] Extension 'test' already exists on Doc`, in case the Emoji class is instantiated more than once in the same process. 

Incidentally, this is the case in the repo's tests. Although the language object is defined as a fixture with function scope, and each function therefore receives a new copy of the language object, the instance of the Doc class used for registering the extension is shared. The tests were hence failing when repeatedly trying to register the same extension. This should be fixed now with `force_extension=True` by default.